### PR TITLE
Indicate repo deprecation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-## Script for creating Service Principal
+# ⛔️ DEPRECATED
+
+This repository is no longer maintained. Please consider referencing the article [Microsoft Docs - Generate a service principal](https://docs.microsoft.com/en-us/azure/azure-government/connect-with-azure-pipelines#generate-a-service-principal) for the maintained version of the `spncreation.ps1` script.


### PR DESCRIPTION
As per @stevevi this standalone dev repo is no longer referenced from the [updated article](https://docs.microsoft.com/en-us/azure/azure-government/connect-with-azure-pipelines#generate-a-service-principal).

This PR updates the `README.md` to indicate this and to direct future viewers of this repository to the appropriate documentation. It is recommended that the repository also be tagged as "deprecated".